### PR TITLE
chore(deps-dev): bump the dependencies group with 2 updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
         "release": "standard-version -s"
     },
     "devDependencies": {
-        "@commitlint/cli": "^18.6.1",
-        "@commitlint/config-conventional": "^18.6.3",
+        "@commitlint/cli": "^19.5.0",
+        "@commitlint/config-conventional": "^19.5.0",
         "standard-version": "^9.5.0"
     },
     "commitlint": {


### PR DESCRIPTION
Bumps the dependencies group with 2 updates: [@commitlint/cli](https://github.com/conventional-changelog/commitlint/tree/HEAD/@commitlint/cli) and [@commitlint/config-conventional](https://github.com/conventional-changelog/commitlint/tree/HEAD/@commitlint/config-conventional).


Updates `@commitlint/cli` from 18.6.1 to 19.5.0
- [Release notes](https://github.com/conventional-changelog/commitlint/releases)
- [Changelog](https://github.com/conventional-changelog/commitlint/blob/master/@commitlint/cli/CHANGELOG.md)
- [Commits](https://github.com/conventional-changelog/commitlint/commits/v19.5.0/@commitlint/cli)

Updates `@commitlint/config-conventional` from 18.6.3 to 19.5.0
- [Release notes](https://github.com/conventional-changelog/commitlint/releases)
- [Changelog](https://github.com/conventional-changelog/commitlint/blob/master/@commitlint/config-conventional/CHANGELOG.md)
- [Commits](https://github.com/conventional-changelog/commitlint/commits/v19.5.0/@commitlint/config-conventional)

---
updated-dependencies:
- dependency-name: "@commitlint/cli" dependency-type: direct:development update-type: version-update:semver-major dependency-group: dependencies
- dependency-name: "@commitlint/config-conventional" dependency-type: direct:development update-type: version-update:semver-major dependency-group: dependencies ...